### PR TITLE
Update dhis2-basic-setup.md

### DIFF
--- a/dhis2-basic-setup.md
+++ b/dhis2-basic-setup.md
@@ -105,7 +105,7 @@ This example assumes name, role and password to be **dhis**.
 
 ```sh
 $ sudo -u postgres psql
-% create user 'dhis' with password 'dhis';
+% create user dhis with password 'dhis';
 % create database "dhis2";
 % grant all privileges on database "dhis2" to dhis;
 % \q


### PR DESCRIPTION
Removed single quotes around username when creating postgresql user, having them does not work on Ubuntu 18 with pgsql 9.6.10 at least, but removing them works.